### PR TITLE
fix: Correct About modal content and JS initialization

### DIFF
--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -362,6 +362,57 @@ class KeyJoltApp {
         const i = Math.floor(Math.log(bytes) / Math.log(k));
         return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
     }
+
+    initAboutModal() {
+        if (!this.aboutModal || !this.aboutLink || !this.closeAboutModalBtn) {
+            // console.warn('About modal elements not found. Skipping modal initialization.');
+            // It's possible these elements are not on every page, so don't warn too loudly.
+            return;
+        }
+
+        this.aboutLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            this.openAboutModal();
+        });
+
+        this.closeAboutModalBtn.addEventListener('click', () => {
+            this.closeAboutModal();
+        });
+
+        window.addEventListener('click', (event) => {
+            if (event.target === this.aboutModal) {
+                this.closeAboutModal();
+            }
+        });
+
+        window.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && this.aboutModal && this.aboutModal.style.display === 'block') {
+                this.closeAboutModal();
+            }
+        });
+    }
+
+    openAboutModal() {
+        if (!this.aboutModal) return;
+        this.aboutModal.style.display = 'block';
+        // Re-initialize Feather icons if they are used inside the modal
+        if (typeof feather !== 'undefined') {
+            feather.replace();
+        }
+        // Focus the close button for accessibility
+        if (this.closeAboutModalBtn) {
+            this.closeAboutModalBtn.focus();
+        }
+    }
+
+    closeAboutModal() {
+        if (!this.aboutModal) return;
+        this.aboutModal.style.display = 'none';
+        // Return focus to the link that opened the modal, if available
+        if (this.aboutLink) {
+            this.aboutLink.focus();
+        }
+    }
 }
 
 // Global functions
@@ -397,58 +448,6 @@ window.resetForm = function() {
 document.addEventListener('DOMContentLoaded', function() {
     window.keyJoltApp = new KeyJoltApp();
 });
-
-// Add modal methods to KeyJoltApp prototype
-KeyJoltApp.prototype.initAboutModal = function() {
-    if (!this.aboutModal || !this.aboutLink || !this.closeAboutModalBtn) {
-        // console.warn('About modal elements not found. Skipping modal initialization.');
-        // It's possible these elements are not on every page, so don't warn too loudly.
-        return;
-    }
-
-    this.aboutLink.addEventListener('click', (e) => {
-        e.preventDefault();
-        this.openAboutModal();
-    });
-
-    this.closeAboutModalBtn.addEventListener('click', () => {
-        this.closeAboutModal();
-    });
-
-    window.addEventListener('click', (event) => {
-        if (event.target === this.aboutModal) {
-            this.closeAboutModal();
-        }
-    });
-
-    window.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && this.aboutModal && this.aboutModal.style.display === 'block') {
-            this.closeAboutModal();
-        }
-    });
-};
-
-KeyJoltApp.prototype.openAboutModal = function() {
-    if (!this.aboutModal) return;
-    this.aboutModal.style.display = 'block';
-    // Re-initialize Feather icons if they are used inside the modal
-    if (typeof feather !== 'undefined') {
-        feather.replace();
-    }
-    // Focus the close button for accessibility
-    if (this.closeAboutModalBtn) {
-        this.closeAboutModalBtn.focus();
-    }
-};
-
-KeyJoltApp.prototype.closeAboutModal = function() {
-    if (!this.aboutModal) return;
-    this.aboutModal.style.display = 'none';
-    // Return focus to the link that opened the modal, if available
-    if (this.aboutLink) {
-        this.aboutLink.focus();
-    }
-};
 
 // Handle page visibility changes to clean up resources
 document.addEventListener('visibilitychange', function() {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -207,15 +207,38 @@
             <div class="modal-body">
                 <div class="about-section">
                     <h3><i data-feather="layers" class="about-icon"></i>Tech Stack</h3>
-                    <p>KeyJolt is built with Spring Boot, Thymeleaf, and vanilla JavaScript.</p>
+                    <h4>Backend:</h4>
+                    <ul>
+                        <li><strong>Framework:</strong> Spring Boot 3.2.0</li>
+                        <li><strong>Language:</strong> Java 17</li>
+                        <li><strong>Security:</strong> Spring Security with custom headers</li>
+                        <li><strong>Cryptography:</strong> Bouncy Castle (PGP), JSch (SSH)</li>
+                        <li><strong>Rate Limiting:</strong> Bucket4j</li>
+                        <li><strong>Build Tool:</strong> Maven</li>
+                    </ul>
+                    <h4>Frontend:</h4>
+                    <ul>
+                        <li><strong>Template Engine:</strong> Thymeleaf</li>
+                        <li><strong>Styling:</strong> Custom CSS with CSS Grid and Flexbox</li>
+                        <li><strong>JavaScript:</strong> Vanilla JS with modern ES6+ features</li>
+                        <li><strong>Icons:</strong> Feather Icons</li>
+                        <li><strong>Responsive:</strong> Mobile-first design patterns</li>
+                    </ul>
+                    <h4>Security & Performance:</h4>
+                    <ul>
+                        <li><strong>HTTPS Ready:</strong> Security headers for production deployment</li>
+                        <li><strong>CSP:</strong> Content Security Policy for XSS protection</li>
+                        <li><strong>Rate Limiting:</strong> Token bucket algorithm</li>
+                        <li><strong>Memory Management:</strong> Automatic resource cleanup</li>
+                    </ul>
                 </div>
                 <div class="about-section">
                     <h3><i data-feather="github" class="about-icon"></i>GitHub</h3>
-                    <p><a href="https://github.com/your-repo/keyjolt" target="_blank">View on GitHub</a></p>
+                    <p><a href="https://github.com/hexawulf/KeyJolt" target="_blank" rel="noopener noreferrer">View on GitHub</a></p>
                 </div>
                 <div class="about-section">
                     <h3><i data-feather="user" class="about-icon"></i>Developer Info</h3>
-                    <p>KeyJolt was developed by [Your Name/Organization].</p>
+                    <p>0xWulf, <a href="mailto:dev@0xwulf.dev">dev@0xwulf.dev</a></p>
                 </div>
                 <div class="about-section">
                     <h3><i data-feather="info" class="about-icon"></i>Version</h3>
@@ -223,7 +246,7 @@
                 </div>
                 <div class="about-section">
                     <h3><i data-feather="calendar" class="about-icon"></i>Date</h3>
-                    <p>October 2023</p>
+                    <p>June 2025</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This commit addresses issues in the About modal:

1.  **Corrected Content:** The placeholder information in the About modal's HTML (`index.html`) has been updated with the accurate and detailed Tech Stack, GitHub link, Developer Info, Version, and Date as specified in the original issue. The tech stack is now formatted with subheadings and lists for better readability.
2.  **JavaScript Refactoring:** The `initAboutModal`, `openAboutModal`, and `closeAboutModal` methods in `script.js` have been moved directly into the `KeyJoltApp` class definition from the prototype. This ensures correct initialization and aligns with better class structuring practices.

These changes ensure the About modal displays the correct information and functions reliably.