### PR TITLE
Fix: Remove redundant Feather Icons CSS link

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>KeyJolt - Secure PGP Key Generator</title>
     <link rel="stylesheet" th:href="@{/css/style.css}">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/feather-icons@4.29.0/dist/feather.css">
     <script src="https://cdn.jsdelivr.net/npm/feather-icons@4.29.0/dist/feather.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
I removed the unnecessary `feather.css` link from `index.html`. This CSS file was causing 404 errors in the browser console as the referenced font files were not present.

Feather Icons are already being loaded and rendered using `feather.min.js`, so the CSS link was redundant. This change eliminates the 404 errors without affecting icon display or functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed a redundant stylesheet link for Feather Icons from the page to streamline resource loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->