### PR TITLE
Fix: Tighten CSP to remove cdn.jsdelivr.net from font-src and style-src

### DIFF
--- a/src/main/java/com/keyjolt/config/SecurityConfig.java
+++ b/src/main/java/com/keyjolt/config/SecurityConfig.java
@@ -40,11 +40,16 @@ public class SecurityConfig {
                 .addHeaderWriter((request, response) -> {
                     response.setHeader("X-Content-Type-Options", "nosniff");
                     response.setHeader("X-XSS-Protection", "1; mode=block");
+                    // CSP tightened:
+                    // font-src set to 'self' to rely on system fonts and avoid external font dependencies.
+                    // style-src set to 'self' and 'unsafe-inline' to use self-hosted stylesheets
+                    // and allow inline styles, avoiding external stylesheet dependencies.
+                    // This aligns with the policy of not using external fonts like Google Fonts.
                     response.setHeader("Content-Security-Policy", 
                         "default-src 'self'; " +
                         "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; " +
-                        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; " +
-                        "font-src 'self' https://cdn.jsdelivr.net; " +
+                        "style-src 'self' 'unsafe-inline'; " +
+                        "font-src 'self'; " +
                         "img-src 'self' data:; " +
                         "connect-src 'self'");
                 })


### PR DESCRIPTION
I've modified the Content Security Policy in `SecurityConfig.java` to make it stricter.

- Changed `font-src` from `'self' https://cdn.jsdelivr.net` to `'self'`.
- Changed `style-src` from `'self' 'unsafe-inline' https://cdn.jsdelivr.net` to `'self' 'unsafe-inline'`.

This change reinforces the application's policy to use system fonts and self-hosted stylesheets, and to not rely on external CDNs like cdn.jsdelivr.net for these resources. This is in line with addressing issues related to loading external fonts (e.g., Google Fonts) by ensuring the CSP does not permit them.

I've also added an explanatory comment to `SecurityConfig.java` detailing these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Strengthened Content-Security-Policy by disallowing external CDN sources for styles and fonts, now permitting only self-hosted and inline styles, and self-hosted fonts.
- **Documentation**
  - Updated comments to clarify reliance on system fonts and self-hosted stylesheets, with no external font dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->