### PR TITLE
Fix: Replace debug printing with SLF4J logging and ensure FileUtils s…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,6 +31,7 @@ spring.servlet.multipart.max-request-size=10MB
 logging.level.com.keyjolt=INFO
 logging.level.org.springframework.security=DEBUG
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} - %msg%n
+logging.file.name=target/spring.log
 
 # Environment Variables (with defaults)
 app.encryption.default-strength=4096


### PR DESCRIPTION
…cheduler shutdown

This commit addresses two issues:

1.  Replaced `System.err.println` calls in `FileUtils.java` with SLF4J's `logger.error()`. This improves log formatting, allows configurable log levels, and is better for production monitoring. Other files were checked, and no other instances of `System.err.println`, `System.out.println`, or `printStackTrace` were found.

2.  Ensured proper shutdown of the `ScheduledExecutorService` in `FileUtils.java` by adding the `@PreDestroy` annotation to the existing `shutdown()` method. This prevents thread leaks and ensures a clean application shutdown. A logger was also added to `FileUtils` to log the shutdown process.

The `pom.xml` already includes `spring-boot-starter`, which provides SLF4J, so no dependency changes were needed.

I confirmed that the application compiles, runs, and the `FileUtils` scheduler shutdown message is logged upon application termination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved error reporting by enhancing logging for file operations and scheduler shutdown.
  - Application logs are now also written to a file at target/spring.log in addition to the console.
- **Refactor**
  - Enhanced lifecycle management for file cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->