### PR TITLE
Fix logback pattern

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIR}/keyjolt.log</file>
         <encoder>
-            <pattern>[%-d{yyyy-MM-dd HH:mm:ss}] [%level] [%thread] %logger{36} - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}] [%level] [%thread] %logger{36} - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${LOG_DIR}/keyjolt.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
@@ -17,7 +17,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%-d{yyyy-MM-dd HH:mm:ss}] [%level] [%thread] %logger{36} - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}] [%level] [%thread] %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## Summary
- correct logback pattern in `logback-spring.xml` for FILE and STDOUT appenders

## Testing
- `mvn -q clean package -DskipTests` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ac24e2988322acd9b3c6d0ded1e5