### PR TITLE
fix: Allow public access to favicon.ico and robots.txt

### DIFF
--- a/src/main/java/com/keyjolt/config/SecurityConfig.java
+++ b/src/main/java/com/keyjolt/config/SecurityConfig.java
@@ -43,8 +43,10 @@ public class SecurityConfig {
                 )
                 // Disable form-based login.
                 // The default Spring Security login page will not be generated.
-                // This is done because we might implement a custom authentication mechanism later (e.g., token-based).
                 .formLogin(formLogin -> formLogin.disable())
+                // Disable HTTP Basic authentication.
+                // This prevents browser authentication popups and ensures it doesn't interfere with permitAll for static resources.
+                .httpBasic(httpBasic -> httpBasic.disable())
                 // Configure session management to be stateless.
                 // This means the application will not create or use HTTP sessions to store security context.
                 // Each request must be authenticated independently, typically using tokens.


### PR DESCRIPTION
Updates Spring Security configuration to explicitly disable HTTP Basic authentication in addition to form login. This ensures that requests to /favicon.ico and /robots.txt are not challenged for authentication and are correctly served as per the permitAll() rule, resolving an issue where they were previously returning 403 Forbidden.