### PR TITLE
Fix: Allow /api/generate in Spring Security config

### DIFF
--- a/src/main/java/com/keyjolt/config/SecurityConfig.java
+++ b/src/main/java/com/keyjolt/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/",
                                 "/generate", // Allow access to the key generation endpoint
+                                "/api/generate", // Allow access to the API endpoint for key generation
                                 "/index", // Assuming /index also serves content like /
                                 "/css/**",
                                 "/js/**",


### PR DESCRIPTION
Updated SecurityConfig.java to include /api/generate in the requestMatchers list. This resolves an issue where requests to this endpoint were being blocked by Spring Security.