### PR TITLE
Fix CORS handling for Spring Security

### DIFF
--- a/src/main/java/com/keyjolt/config/SecurityConfig.java
+++ b/src/main/java/com/keyjolt/config/SecurityConfig.java
@@ -7,9 +7,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import java.util.List; // Added this line
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -78,18 +80,16 @@ public class SecurityConfig {
         return new InMemoryUserDetailsManager(adminUser);
     }
 
-    // Bean for configuring CORS (Cross-Origin Resource Sharing).
-    // This allows requests from specified origins (e.g., your frontend application).
     @Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**") // Apply CORS configuration to all paths
-                        .allowedOrigins("https://keyjolt.piapps.dev", "https://keyjolt.dev") // Allow requests from these origins
-                        .allowedMethods("GET", "POST") // Allow specified HTTP methods
-                        .allowCredentials(true); // Allow credentials like cookies, authorization headers
-            }
-        };
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("https://keyjolt.dev", "https://keyjolt.piapps.dev"));
+        config.setAllowedMethods(List.of("GET", "POST"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }


### PR DESCRIPTION
Replaced WebMvcConfigurer with CorsConfigurationSource to correctly link Spring Security's CORS support with the custom CORS configuration. This resolves issues with cross-origin POST requests being rejected with 403 Forbidden errors.