### PR TITLE
Fix CORS and permit /api/generate endpoint

### DIFF
--- a/src/main/java/com/keyjolt/config/SecurityConfig.java
+++ b/src/main/java/com/keyjolt/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/",
                                 "/generate", // Allow access to the key generation endpoint
+                                "/api/generate", // Allow access to the API key generation endpoint
                                 "/index", // Assuming /index also serves content like /
                                 "/css/**",
                                 "/js/**",


### PR DESCRIPTION
Updated Spring Security configuration to include /api/generate in the list of publicly accessible endpoints. This resolves 403 Forbidden errors when the frontend posts to this path.

Previously, CORS handling was fixed by replacing WebMvcConfigurer with CorsConfigurationSource.