### PR TITLE
Fix downloads blocked by security

### DIFF
--- a/src/main/java/com/keyjolt/config/SecurityConfig.java
+++ b/src/main/java/com/keyjolt/config/SecurityConfig.java
@@ -55,7 +55,8 @@ public class SecurityConfig {
                                 "/apple-touch-icon.png",
                                 "/android-chrome-*.png", // Wildcard for different sizes
                                 "/site.webmanifest",
-                                "/robots.txt"
+                                "/robots.txt",
+                                "/download/**" // Allow public access to generated files
                         ).permitAll()
                         // Require authentication for all other requests.
                         .anyRequest().authenticated()

--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -440,35 +440,29 @@ class KeyJoltApp {
     async downloadFile(downloadUrl, filename) {
         fetch(downloadUrl)
             .then(response => {
-                const contentType = response.headers.get('content-type');
-
                 if (!response.ok) {
-                    if (contentType && contentType.includes('application/json')) {
+                    const contentType = response.headers.get('content-type') || '';
+
+                    if (contentType.includes('application/json')) {
                         return response.json().then(data => {
-                            console.error('Download failed:', data.error);
+                            console.error('Download failed:', data.error || 'Unknown error.');
                         });
-                    } else {
-                        throw new Error('Download failed with unknown error.');
                     }
+
+                    throw new Error(`Download failed with status ${response.status}`);
                 }
 
-                if (contentType && contentType.includes('application/json')) {
-                    return response.json().then(data => {
-                        console.error('Download failed:', data.error);
-                    });
-                } else {
-                    return response.blob().then(blob => {
-                        const link = document.createElement('a');
-                        link.href = window.URL.createObjectURL(blob);
-                        link.download = filename;
-                        document.body.appendChild(link);
-                        link.click();
-                        document.body.removeChild(link);
-                    });
-                }
+                return response.blob().then(blob => {
+                    const link = document.createElement('a');
+                    link.href = window.URL.createObjectURL(blob);
+                    link.download = filename;
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+                });
             })
             .catch(error => {
-                console.error('Unexpected fetch error:', error);
+                console.error('Unexpected fetch error:', error.message);
             });
     }
 


### PR DESCRIPTION
## Summary
- allow public access to `/download/**` in Spring Security config
- prevent fetch() from assuming JSON on error

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab0b9fa6c8322b0df579c30b7797d