### PR TITLE
Block WordPress paths

### DIFF
--- a/src/main/java/com/keyjolt/config/SecurityConfig.java
+++ b/src/main/java/com/keyjolt/config/SecurityConfig.java
@@ -58,6 +58,12 @@ public class SecurityConfig {
                                 "/robots.txt",
                                 "/download/**" // Allow public access to generated files
                         ).permitAll()
+                        // Deny common WordPress paths often probed by bots
+                        .requestMatchers(
+                                "/wp-admin/**",
+                                "/wordpress/**",
+                                "/wp-login.php"
+                        ).denyAll()
                         // Require authentication for all other requests.
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/keyjolt/controller/BlockedPathController.java
+++ b/src/main/java/com/keyjolt/controller/BlockedPathController.java
@@ -1,0 +1,18 @@
+package com.keyjolt.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Simple controller to return 404 for common WordPress probing paths.
+ */
+@Controller
+public class BlockedPathController {
+
+    @RequestMapping({"/wp-admin/**", "/wordpress/**", "/wp-login.php"})
+    public ResponseEntity<Void> handleBlocked() {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+}


### PR DESCRIPTION
## Summary
- deny WordPress style paths in `SecurityConfig`
- add optional controller returning 404 for bots hitting those paths

## Testing
- `mvn -q package -DskipTests` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686245ca38b083228097e2875f25912b